### PR TITLE
Fix identification of Git root on new JDK versions

### DIFF
--- a/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradleGraderPlugin.kt
+++ b/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradleGraderPlugin.kt
@@ -16,7 +16,6 @@ import org.gradle.api.plugins.quality.CheckstyleExtension
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
-import java.io.File
 import java.nio.file.Files
 
 /**

--- a/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradleGraderPlugin.kt
+++ b/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradleGraderPlugin.kt
@@ -76,7 +76,8 @@ class GradleGraderPlugin : Plugin<Project> {
             // Check VCS
             if (config.vcs.git) {
                 val gitRepo = try {
-                    FileRepositoryBuilder().setMustExist(true).addCeilingDirectory(File(".")).findGitDir().build()
+                    val ceiling = project.rootProject.projectDir.parentFile // Go an extra level up to work around a JGit bug
+                    FileRepositoryBuilder().setMustExist(true).addCeilingDirectory(ceiling).findGitDir(project.projectDir).build()
                 } catch (_: Exception) { exitManager.fail("Grader Git integration is enabled but the project isn't a Git repository.") }
                 gradeTask.gitConfig = gitRepo.config
                 val lastCommit = gitRepo.resolve(Constants.HEAD).name


### PR DESCRIPTION
This fixes https://cs125-forum.cs.illinois.edu/t/not-a-git-repository-issue/28604/23.

It seems that somewhere along the line between Java 8 and Java 13, something about the choice of the initial working directory was changed. In earlier versions, the Gradle JVM's working directory, as observed by `File(".")`, is the project directory. In later versions, it's the Gradle JAR file's containing directory, which is somewhere entirely outside the project. That discrepancy caused our Git repository check to always fail when run with a modern JDK set as the Gradle JDK. (Of course, changing the Gradle JDK away from the embedded JDK is a bad idea for Android projects, but this change makes the eventual problems more diagnosable and could be important for non-Android assignments.)

For extra fun, there's a bug (or at least difference from the `addCeilingDirectory` documentation) in the implementation of JGit's `findGitDir` function. Any ceiling directories are treated as exclusive upper bounds and will not be checked for Git-repository-ness. This didn't cause any observable problems before because of weirdness in `File` comparisons, but now that problem must be worked around by specifying the root project's *parent* directory as the ceiling.