### PR TITLE
Fix "array contains no element matching the predicate"

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -396,7 +396,8 @@ This property is an array of objects, one for each scoring component
 * `pointsPossible` is the number of points possible to earn from this item.
 * `pointsEarned` is number of points earned: all points possible if the check/test succeeded,
   or zero if failed.
-* `type` identifies what kind of item this is: `compileError`, `checkstyle`, or `test`.
+* `type` identifies what kind of item this is: `compileError`, `checkstyle`,
+  `testInitializationError`, or `test`.
 
 `compileError` items have this additional property:
 
@@ -407,10 +408,14 @@ This property is an array of objects, one for each scoring component
 * `ran` is whether `checkstyle` processed the sources without crashing and generated a report.
 * `passed` is whether the report indicated no style violations.
 
+`testInitializationError` items have these additional properties:
+* `className` is the fully qualified class name of the test class that failed to initialize.
+* `module` is the name of the Gradle subproject containing the crashed test class.
+
 `test` items have these additional properties:
 
 * `module` is the name of the Gradle subproject containing this test.
-* `className` is the fully-qualified Java class name of the test suite.
+* `className` is the fully-qualified class name of the test suite.
 * `testCase` is the test method name.
 * `passed` is whether the test completed successfully.
 * `failureStackTrace` is the stack trace of the exception that caused the test case to fail,

--- a/README.adoc
+++ b/README.adoc
@@ -409,8 +409,10 @@ This property is an array of objects, one for each scoring component
 * `passed` is whether the report indicated no style violations.
 
 `testInitializationError` items have these additional properties:
-* `className` is the fully qualified class name of the test class that failed to initialize.
 * `module` is the name of the Gradle subproject containing the crashed test class.
+* `className` is the fully qualified class name of the test class that failed to initialize.
+* `failureStackTrace` is the stack trace of the exception that caused initialization to
+  fail.
 
 `test` items have these additional properties:
 

--- a/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradeTask.kt
+++ b/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradeTask.kt
@@ -147,6 +147,7 @@ open class GradeTask : DefaultTask() {
                         val initFailResults = JsonObject()
                         initFailResults.addProperty("module", task.project.name)
                         initFailResults.addProperty("className", className)
+                        initFailResults.addProperty("failureStackTrace", it.getElementsByTagName("failure").item(0)?.textContent)
                         initFailResults.addProperty("description", className.substringAfterLast('.'))
                         initFailResults.addProperty("pointsPossible", 0)
                         initFailResults.addProperty("pointsEarned", 0)

--- a/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradeTask.kt
+++ b/plugin/src/main/java/edu/illinois/cs/cs125/gradlegrader/plugin/GradeTask.kt
@@ -128,57 +128,59 @@ open class GradeTask : DefaultTask() {
 
         // Grade tests/projects
         val projectResults = JsonArray()
+        fun processTestFile(task: Task, loader: ClassLoader, file: File) {
+            val xml = documentBuilder.parse(file)
+            val className = xml.documentElement.getAttribute("name")
+            val testSuiteClass = loader.loadClass(className)!!
+            val testcaseList = xml.documentElement.getElementsByTagName("testcase")
+            (0 until testcaseList.length).map { n -> testcaseList.item(n) as Element }.forEach examineMethod@{
+                val testName = it.getAttribute("name")
+                val methodName = testName.substringBefore('[').substringBefore('(')
+                if (methodName in setOf("initializationError", "classMethod")) {
+                    val initFailResults = JsonObject()
+                    initFailResults.addProperty("module", task.project.name)
+                    initFailResults.addProperty("className", className)
+                    initFailResults.addProperty("failureStackTrace", it.getElementsByTagName("failure").item(0)?.textContent)
+                    initFailResults.addProperty("description", className.substringAfterLast('.'))
+                    initFailResults.addProperty("pointsPossible", 0)
+                    initFailResults.addProperty("pointsEarned", 0)
+                    initFailResults.addProperty("explanation", "Initialization failed")
+                    initFailResults.addProperty("type", "testInitializationError")
+                    scoringResults.add(initFailResults)
+                    return@examineMethod
+                }
+                val testMethod = testSuiteClass.methods.firstOrNull { m -> m.name == methodName } ?: return@examineMethod
+                val gradedAnnotation = testMethod.getDeclaredAnnotation(Graded::class.java) ?: return@examineMethod
+                val methodResults = JsonObject()
+                testMethod.getAnnotationsByType(Tag::class.java).forEach { tag -> methodResults.addProperty(tag.name, tag.value) }
+                methodResults.addProperty("module", task.project.name)
+                methodResults.addProperty("className", className)
+                methodResults.addProperty("testCase", testName)
+                val passed = it.getElementsByTagName("failure").length == 0 && it.getElementsByTagName("skipped").length == 0
+                methodResults.addProperty("passed", passed)
+                methodResults.addProperty("pointsPossible", gradedAnnotation.points)
+                methodResults.addProperty("pointsEarned", if (passed) gradedAnnotation.points else 0)
+                if (!passed) {
+                    methodResults.addProperty("failureStackTrace", it.getElementsByTagName("failure").item(0)?.textContent)
+                }
+                methodResults.addProperty(
+                    "description",
+                    if (gradedAnnotation.friendlyName.isEmpty()) methodName else gradedAnnotation.friendlyName
+                )
+                methodResults.addProperty("explanation", testName + (if (passed) " passed" else " failed"))
+                methodResults.addProperty("type", "test")
+                scoringResults.add(methodResults)
+                pointsPossible += gradedAnnotation.points
+                pointsEarned += if (passed) gradedAnnotation.points else 0
+            }
+        }
         gradedTests.forEach { task ->
-            // Prepare a class loader that can access test suite classes
-            val loader = URLClassLoader(task.classpath.map { it.toURI().toURL() }.toTypedArray(), javaClass.classLoader)
-
-            // Load the report XML files
+            // Process the report XML files with a class loader that can access test classes
             var compiled = false
-            task.reports.junitXml.destination.listFiles { _, name -> name.endsWith(".xml") }?.forEach { file ->
-                compiled = true
-                val xml = documentBuilder.parse(file)
-                val className = xml.documentElement.getAttribute("name")
-                val testSuiteClass = loader.loadClass(className)!!
-                val testcaseList = xml.documentElement.getElementsByTagName("testcase")
-                (0 until testcaseList.length).map { n -> testcaseList.item(n) as Element }.forEach examineMethod@{
-                    val testName = it.getAttribute("name")
-                    val methodName = testName.substringBefore('[').substringBefore('(')
-                    if (methodName in setOf("initializationError", "classMethod")) {
-                        val initFailResults = JsonObject()
-                        initFailResults.addProperty("module", task.project.name)
-                        initFailResults.addProperty("className", className)
-                        initFailResults.addProperty("failureStackTrace", it.getElementsByTagName("failure").item(0)?.textContent)
-                        initFailResults.addProperty("description", className.substringAfterLast('.'))
-                        initFailResults.addProperty("pointsPossible", 0)
-                        initFailResults.addProperty("pointsEarned", 0)
-                        initFailResults.addProperty("explanation", "Initialization failed")
-                        initFailResults.addProperty("type", "testInitializationError")
-                        scoringResults.add(initFailResults)
-                        return@examineMethod
-                    }
-                    val testMethod = testSuiteClass.methods.firstOrNull { m -> m.name == methodName } ?: return@examineMethod
-                    val gradedAnnotation = testMethod.getDeclaredAnnotation(Graded::class.java) ?: return@examineMethod
-                    val methodResults = JsonObject()
-                    testMethod.getAnnotationsByType(Tag::class.java).forEach { tag -> methodResults.addProperty(tag.name, tag.value) }
-                    methodResults.addProperty("module", task.project.name)
-                    methodResults.addProperty("className", className)
-                    methodResults.addProperty("testCase", testName)
-                    val passed = it.getElementsByTagName("failure").length == 0 && it.getElementsByTagName("skipped").length == 0
-                    methodResults.addProperty("passed", passed)
-                    methodResults.addProperty("pointsPossible", gradedAnnotation.points)
-                    methodResults.addProperty("pointsEarned", if (passed) gradedAnnotation.points else 0)
-                    if (!passed) {
-                        methodResults.addProperty("failureStackTrace", it.getElementsByTagName("failure").item(0)?.textContent)
-                    }
-                    methodResults.addProperty(
-                        "description",
-                        if (gradedAnnotation.friendlyName.isEmpty()) methodName else gradedAnnotation.friendlyName
-                    )
-                    methodResults.addProperty("explanation", testName + (if (passed) " passed" else " failed"))
-                    methodResults.addProperty("type", "test")
-                    scoringResults.add(methodResults)
-                    pointsPossible += gradedAnnotation.points
-                    pointsEarned += if (passed) gradedAnnotation.points else 0
+            URLClassLoader(task.classpath.map { it.toURI().toURL() }.toTypedArray(), javaClass.classLoader).use { loader ->
+                task.reports.junitXml.destination.listFiles { _, name -> name.endsWith(".xml") }?.forEach { file ->
+                    compiled = true
+                    processTestFile(task, loader, file)
                 }
             }
 


### PR DESCRIPTION
This fixes https://cs125-forum.cs.illinois.edu/t/array-contains-no-element-compiler-error/29686.

When JUnit can't initialize or finds a problem with a test class, it records the problem as a failed test case with a method name of `classMethod` or `initializationError`. GradleGrader still looks for a test method with that name and, failing to find it in a filtered `first` call, crashes with "array contains no element matching the predicate."

This change makes GradleGrader specifically recognize those pseudo-tests and produce a more helpful error without failing the entire build. It also gracefully ignores unknown methods in case other runners use different names for similar issues.